### PR TITLE
Fix apostrophes around id string

### DIFF
--- a/src/SearchQueryService/Services/SolrSearchQueryBuilder.cs
+++ b/src/SearchQueryService/Services/SolrSearchQueryBuilder.cs
@@ -17,7 +17,8 @@ namespace SearchQueryService.Services
             { @"(\w+)\s+lt\s+([^\s]+)", "$1:{* TO $2}" },
             { @"\(not\s(\w+)\)", "($1: false)" },
             { @"\((\w+)\)", "($1: true)" },
-            { @"(\w+)\s+ne", "NOT $1:" }
+            { @"(\w+)\s+ne", "NOT $1:" },
+            { @"\(Id:\s?'(\d*)'\)", "(id: $1)" }
         };
 
         public string Build(string indexName, AzSearchParams searchParams)
@@ -58,16 +59,17 @@ namespace SearchQueryService.Services
 
         private static string ConvertAzFilterQuery(string filter)
         {
+            filter = filter.Replace(" eq", ":")
+                           .Replace(" and ", " AND ")
+                           .Replace(" or ", " OR ")
+                           .Replace(" not ", " NOT ");
+
             foreach (var kv in _replacements)
             {
                 filter = Regex.Replace(filter, kv.Key, kv.Value);
             }
 
-            return filter.Replace(" eq", ":")
-                         .Replace(" and ", " AND ")
-                         .Replace(" or ", " OR ")
-                         .Replace(" not ", " NOT ")
-                         .Replace("(Id:", "(id:");
+            return filter;
         }
     }
 }


### PR DESCRIPTION
+ Fix apostrophes around id string 
+ Replace order of operations (regex.replace and .Replace), in case the query contains `eq` instead of `:`
![obrázok](https://user-images.githubusercontent.com/28986303/174783039-307b9cb0-9b84-4989-bb4c-3dbdbf497303.png)
