### PR TITLE
Heath check

### DIFF
--- a/src/SearchQueryService/Helpers/SolrHealthCheck.cs
+++ b/src/SearchQueryService/Helpers/SolrHealthCheck.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SearchQueryService.Services;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SearchQueryService.Helpers
+{
+    public class SolrHealthCheck : IHealthCheck
+    {
+        private readonly SolrService _solrService;
+
+        public SolrHealthCheck(SolrService solrService)
+        {
+            _solrService = solrService;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            bool isHealthy = await _solrService.IsHealthy();
+
+            if (isHealthy)
+            {
+                return HealthCheckResult.Healthy("Solr is health.");
+            }
+
+            return new HealthCheckResult(context.Registration.FailureStatus, "Solr has some init failures.");
+        }
+    }
+}

--- a/src/SearchQueryService/SearchQueryService.csproj
+++ b/src/SearchQueryService/SearchQueryService.csproj
@@ -6,7 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <DockerfileContext>..\..</DockerfileContext>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SearchQueryService/Services/SolrService.cs
+++ b/src/SearchQueryService/Services/SolrService.cs
@@ -88,10 +88,24 @@ namespace SearchQueryService.Services
             return schemaResponse!.Fields.Count;
         }
 
+        public async Task<bool> IsHealthy()
+        {
+            SolrStatus result = await _httpClient.GetFromJsonAsync<SolrStatus>("admin/cores?action=STATUS");
+
+            return result.InitFailures.Count == 0;
+        }
+
         private static Url GetSchemaUrl(string indexName, string segment = "")
             => Url.Combine(indexName, "schema", segment);
 
         public async Task<SearchResponse> SearchAsync(string indexName, AzSearchParams searchParams)
             => await _httpClient.GetFromJsonAsync<SearchResponse>(_searchQueryBuilder.Build(indexName, searchParams));
+
+        public class SolrStatus
+        {
+            public Dictionary<string, object> Status { get; set; }
+
+            public Dictionary<string, object> InitFailures { get; set; }
+        }
     }
 }

--- a/src/SearchQueryService/Startup.cs
+++ b/src/SearchQueryService/Startup.cs
@@ -36,7 +36,10 @@ namespace SearchQueryService
             {
                 httpClient.BaseAddress = Tools.GetSearchUrl();
             }).AddPolicyHandler(GetRetryPolicy());
-            services.AddHealthChecks();
+            services
+                .AddHealthChecks()
+                .AddCheck<SolrHealthCheck>("Solr");
+
             services.AddHttpLogging(options =>
             {
                 options.LoggingFields = HttpLoggingFields.ResponsePropertiesAndHeaders |


### PR DESCRIPTION
Solr sometimes fails to start. We need to know about it in the Kubernetes cluster. That's why I added a health check here, which checks if there are any failures.