### PR TITLE
Waiting for Indexes Zip file settings

### DIFF
--- a/src/SearchQueryService/Indexes/IndexesProcessorOptions.cs
+++ b/src/SearchQueryService/Indexes/IndexesProcessorOptions.cs
@@ -3,5 +3,7 @@
     public class IndexesProcessorOptions
     {
         public int WaitForFilesRetryCount { get; set; }
+
+        public bool WaitForIndexesZip { get; set; }
     }
 }

--- a/src/SearchQueryService/SearchQueryService.csproj
+++ b/src/SearchQueryService/SearchQueryService.csproj
@@ -6,7 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <DockerfileContext>..\..</DockerfileContext>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SearchQueryService/appsettings.json
+++ b/src/SearchQueryService/appsettings.json
@@ -18,7 +18,8 @@
         "RemoveNullFieldsOnMerge": true
     },
     "IndexesProcessor": {
-        "WaitForFilesRetryCount": 60
+        "WaitForFilesRetryCount": 60,
+        "WaitForIndexesZip": false
     },
     "AllowedHosts": "*"
 }


### PR DESCRIPTION
The original wait for files didn't work because there were files in that directory. So I introduced a setting specifically for the zip file.